### PR TITLE
log/slog: reduce allocs on Any value handling

### DIFF
--- a/src/log/slog/encoder.go
+++ b/src/log/slog/encoder.go
@@ -1,0 +1,12 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package slog
+
+type encoder interface {
+	reset()
+	free()
+	encode(v any) error
+	bytes() []byte
+}

--- a/src/log/slog/internal/benchmarks/benchmarks.go
+++ b/src/log/slog/internal/benchmarks/benchmarks.go
@@ -37,6 +37,11 @@ var (
 	testInt      = 32768
 	testDuration = 23 * time.Second
 	testError    = errors.New("fail")
+	testEvent    = &event{
+		ID:          "testing_event_#01",
+		Description: "Some text for this description to simulate a real scenario.",
+		CreatedAt:   time.Date(2025, time.July, 5, 0, 0, 0, 0, time.UTC),
+	}
 )
 
 var testAttrs = []slog.Attr{
@@ -48,3 +53,9 @@ var testAttrs = []slog.Attr{
 }
 
 const wantText = "time=1651363200 level=0 msg=Test logging, but use a somewhat realistic message length. string=7e3b3b2aaeff56a7108fe11e154200dd/7819479873059528190 status=32768 duration=23000000000 time=1651363200 error=fail\n"
+
+type event struct {
+	ID          string    `json:"id"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/src/log/slog/internal/benchmarks/benchmarks_test.go
+++ b/src/log/slog/internal/benchmarks/benchmarks_test.go
@@ -85,7 +85,7 @@ func BenchmarkAttrs(b *testing.B) {
 							slog.Int("status", testInt),
 							slog.Duration("duration", testDuration),
 							slog.Time("time", testTime),
-							slog.Any("error", testError),
+							slog.Any("event", testEvent),
 						)
 					},
 				},
@@ -133,7 +133,7 @@ func BenchmarkAttrs(b *testing.B) {
 							slog.Int("status", testInt),
 							slog.Duration("duration", testDuration),
 							slog.Time("time", testTime),
-							slog.Any("error", testError),
+							slog.Any("event", testEvent),
 						)
 					},
 				},

--- a/src/log/slog/text_handler_test.go
+++ b/src/log/slog/text_handler_test.go
@@ -168,9 +168,14 @@ func TestNeedsQuoting(t *testing.T) {
 		{"a b", true},
 		{"badutf8\xF6", true},
 	} {
-		got := needsQuoting(test.in)
+		got := needsQuotingString(test.in)
 		if got != test.want {
-			t.Errorf("%q: got %t, want %t", test.in, got, test.want)
+			t.Errorf("needsQuotingString: %q: got %t, want %t", test.in, got, test.want)
+		}
+
+		got = needsQuotingBytes([]byte(test.in))
+		if got != test.want {
+			t.Errorf("needsQuotingBytes: %q: got %t, want %t", test.in, got, test.want)
 		}
 	}
 }


### PR DESCRIPTION
This reduces allocations for handling Any values by reusing the JSON Encoder and using `fmt.Fprint` instead of `fmt.Sprint` for value formatting.

Fixes #74645

---
🔄 **This is a mirror of [upstream PR #74646](https://github.com/golang/go/pull/74646)**