### PR TITLE
cmd/go: clarify that DiskPath should not contain file extension

### DIFF
--- a/src/cmd/go/internal/cacheprog/cacheprog.go
+++ b/src/cmd/go/internal/cacheprog/cacheprog.go
@@ -122,5 +122,7 @@ type Response struct {
 
 	// DiskPath is the absolute path on disk of the body corresponding to a
 	// "get" (on cache hit) or "put" request's ActionID.
+	// The filename in DiskPath should not contain a file extension to ensure
+	// compatibility with tools that filter files based on extensions.
 	DiskPath string `json:",omitempty"`
 }


### PR DESCRIPTION
Add documentation to clarify that the DiskPath field in GOCACHEPROG
Response should not contain a file extension. This prevents issues
with tools like golangci-lint that filter files based on extensions.

Fixes #74451

---
🔄 **This is a mirror of [upstream PR #74484](https://github.com/golang/go/pull/74484)**