### PR TITLE
crypto/cipher: add a new func NewGCMWithNonceSizeAndTagSize allows the user to specify the nonce size and tag size.

### DIFF
--- a/src/crypto/cipher/gcm.go
+++ b/src/crypto/cipher/gcm.go
@@ -63,6 +63,15 @@ func NewGCMWithTagSize(cipher Block, tagSize int) (AEAD, error) {
 	return newGCM(cipher, gcmStandardNonceSize, tagSize)
 }
 
+// NewGCMWithNonceSizeAndTagSize  allows the user to specify the nonce size and tag size.
+// This is useful for compatibility with existing cryptosystems that use non-standard nonce sizes and tag sizes.
+func NewGCMWithNonceSizeAndTagSize(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+	if fips140only.Enabled {
+		return nil, errors.New("crypto/cipher: use of GCM with arbitrary IVs is not allowed in FIPS 140-only mode, use NewGCMWithRandomNonce")
+	}
+	return newGCM(cipher, nonceSize, tagSize)
+}
+
 func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
 	c, ok := cipher.(*aes.Block)
 	if !ok {


### PR DESCRIPTION
This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them

---
🔄 **This is a mirror of [upstream PR #74467](https://github.com/golang/go/pull/74467)**