### PR TITLE
net/mail: prevent whitespace in domain part of addr-spec

### DIFF
--- a/src/net/mail/message.go
+++ b/src/net/mail/message.go
@@ -549,7 +549,8 @@ func (p *addrParser) consumeAddrSpec() (spec string, err error) {
 
 	// domain = dot-atom / domain-literal
 	var domain string
-	p.skipSpace()
+	// domain part does not allow whitespace characters, so skipSpace cannot be called here
+	// p.skipSpace()
 	if p.empty() {
 		return "", errors.New("mail: no domain in addr-spec")
 	}


### PR DESCRIPTION
Updated the addrParser's consumeAddrSpec function to clarify that whitespace characters are not allowed in the domain part of an email address. Removed the call to skipSpace to enforce this rule.

---
🔄 **This is a mirror of upstream PR #74920**