### PR TITLE
types2: omit redundant generic type instantiation error if type is invalid

### DIFF
--- a/src/cmd/compile/internal/types2/typexpr.go
+++ b/src/cmd/compile/internal/types2/typexpr.go
@@ -194,7 +194,7 @@ func (check *Checker) validVarType(e syntax.Expr, typ Type) {
 func (check *Checker) definedType(e syntax.Expr, def *TypeName) Type {
 	typ := check.typInternal(e, def)
 	assert(isTyped(typ))
-	if isGeneric(typ) {
+	if isGeneric(typ) && isValid(typ) {
 		check.errorf(e, WrongTypeArgCount, "cannot use generic type %s without instantiation", typ)
 		typ = Typ[Invalid]
 	}

--- a/test/fixedbugs/issue74725.go
+++ b/test/fixedbugs/issue74725.go
@@ -1,0 +1,6 @@
+// errorcheck
+
+package main
+
+type a = b[int] // ERROR "invalid recursive type a\n.*a refers to b\n.*b refers to a"
+type b[_ any] = a


### PR DESCRIPTION
Fixes: [#74725](https://github.com/golang/go/issues/74725)

---
🔄 **This is a mirror of upstream PR #74996**