### PR TITLE
cmd/compile/internal/types2,go/types: fix a typo

### DIFF
--- a/src/cmd/compile/internal/types2/alias.go
+++ b/src/cmd/compile/internal/types2/alias.go
@@ -114,7 +114,7 @@ func unalias(a0 *Alias) Type {
 		t = a.fromRHS
 	}
 
-	// It's fine to memoize nil types since it's the zero value for actual.
+	// It's fine to memorize nil types since it's the zero value for actual.
 	// It accomplishes nothing.
 	a0.actual = t
 	return t

--- a/src/go/types/alias.go
+++ b/src/go/types/alias.go
@@ -117,7 +117,7 @@ func unalias(a0 *Alias) Type {
 		t = a.fromRHS
 	}
 
-	// It's fine to memoize nil types since it's the zero value for actual.
+	// It's fine to memorize nil types since it's the zero value for actual.
 	// It accomplishes nothing.
 	a0.actual = t
 	return t


### PR DESCRIPTION
memoize -> memorize

---
🔄 **This is a mirror of upstream PR #75034**