### PR TITLE
runtime: move buffer allocation outside loop in randinit

### DIFF
--- a/src/runtime/rand.go
+++ b/src/runtime/rand.go
@@ -64,8 +64,8 @@ func randinit() {
 	if startupRand != nil {
 		// Overwrite startupRand instead of clearing it, in case cgo programs
 		// access it after we used it.
+		buf := make([]byte, 8)
 		for len(startupRand) > 0 {
-			buf := make([]byte, 8)
 			for {
 				if x, ok := globalRand.state.Next(); ok {
 					byteorder.BEPutUint64(buf, x)


### PR DESCRIPTION
Move buf := make([]byte, 8) allocation outside the for loop in randinit() to avoid repeated memory allocations. The same 8-byte buffer can be safely reused across all iterations when overwriting startupRand, as each iteration fills the entire buffer before use. This eliminates unnecessary allocations during runtime initialization while maintaining identical functionality.

---
🔄 **This is a mirror of upstream PR #75171**