### PR TITLE
all: replace strings.Split with strings.SplitSeq

### DIFF
--- a/src/go/ast/ast.go
+++ b/src/go/ast/ast.go
@@ -1123,7 +1123,7 @@ func generator(file *File) (string, bool) {
 			// opt: check Contains first to avoid unnecessary array allocation in Split.
 			const prefix = "// Code generated "
 			if strings.Contains(comment.Text, prefix) {
-				for _, line := range strings.Split(comment.Text, "\n") {
+				for line := range strings.SplitSeq(comment.Text, "\n") {
 					if rest, ok := strings.CutPrefix(line, prefix); ok {
 						if gen, ok := strings.CutSuffix(rest, " DO NOT EDIT."); ok {
 							return gen, true

--- a/src/go/build/build.go
+++ b/src/go/build/build.go
@@ -1708,7 +1708,7 @@ Lines:
 // that affect the way cgo's C code is built.
 func (ctxt *Context) saveCgo(filename string, di *Package, cg *ast.CommentGroup) error {
 	text := cg.Text()
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		orig := line
 
 		// Line is

--- a/src/go/build/constraint/expr.go
+++ b/src/go/build/constraint/expr.go
@@ -406,9 +406,9 @@ func parsePlusBuildExpr(text string) (Expr, error) {
 	size := 0
 
 	var x Expr
-	for _, clause := range strings.Fields(text) {
+	for clause := range strings.FieldsSeq(text) {
 		var y Expr
-		for _, lit := range strings.Split(clause, ",") {
+		for lit := range strings.SplitSeq(clause, ",") {
 			var z Expr
 			var neg bool
 			if strings.HasPrefix(lit, "!!") || lit == "!" {

--- a/src/internal/buildcfg/cfg.go
+++ b/src/internal/buildcfg/cfg.go
@@ -336,7 +336,7 @@ func (f gowasmFeatures) String() string {
 }
 
 func gowasm() (f gowasmFeatures) {
-	for _, opt := range strings.Split(envOr("GOWASM", ""), ",") {
+	for opt := range strings.SplitSeq(envOr("GOWASM", ""), ",") {
 		switch opt {
 		case "satconv":
 			f.SatConv = true

--- a/src/internal/buildcfg/exp.go
+++ b/src/internal/buildcfg/exp.go
@@ -113,7 +113,7 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
 		}
 
 		// Parse names.
-		for _, f := range strings.Split(goexp, ",") {
+		for f := range strings.SplitSeq(goexp, ",") {
 			if f == "" {
 				continue
 			}

--- a/src/internal/testenv/testenv.go
+++ b/src/internal/testenv/testenv.go
@@ -484,7 +484,7 @@ func WriteImportcfg(t testing.TB, dstPath string, packageFiles map[string]string
 			t.Fatalf("%v: %v\n%s", cmd, err, cmd.Stderr)
 		}
 
-		for _, line := range strings.Split(string(out), "\n") {
+		for line := range strings.SplitSeq(string(out), "\n") {
 			if line == "" {
 				continue
 			}

--- a/src/internal/trace/traceviewer/mmu.go
+++ b/src/internal/trace/traceviewer/mmu.go
@@ -69,7 +69,7 @@ var utilFlagNames = map[string]trace.UtilFlags{
 
 func requestUtilFlags(r *http.Request) trace.UtilFlags {
 	var flags trace.UtilFlags
-	for _, flagStr := range strings.Split(r.FormValue("flags"), "|") {
+	for flagStr := range strings.SplitSeq(r.FormValue("flags"), "|") {
 		flags |= utilFlagNames[flagStr]
 	}
 	return flags
@@ -119,7 +119,7 @@ func (m *mmu) HandlePlot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var quantiles []float64
-	for _, flagStr := range strings.Split(r.FormValue("flags"), "|") {
+	for flagStr := range strings.SplitSeq(r.FormValue("flags"), "|") {
 		if flagStr == "mut" {
 			quantiles = []float64{0, 1 - .999, 1 - .99, 1 - .95}
 			break

--- a/src/os/exec/lp_windows.go
+++ b/src/os/exec/lp_windows.go
@@ -123,7 +123,7 @@ func pathExt() []string {
 	var exts []string
 	x := os.Getenv(`PATHEXT`)
 	if x != "" {
-		for _, e := range strings.Split(strings.ToLower(x), `;`) {
+		for e := range strings.SplitSeq(strings.ToLower(x), `;`) {
 			if e == "" {
 				continue
 			}


### PR DESCRIPTION
In Go 1.25+, strings.SplitSeq offers better performance.

---
🔄 **This is a mirror of upstream PR #75259**