### PR TITLE
net/http: clarify panic conditions in Handle, HandleFunc, AddInsecureBypassPattern

### DIFF
--- a/src/net/http/csrf.go
+++ b/src/net/http/csrf.go
@@ -90,6 +90,10 @@ var sentinelHandler Handler = &noopHandler{}
 // would redirect to a pattern (e.g. after cleaning the path or adding a
 // trailing slash) are not.
 //
+// AddInsecureBypassPattern panics if the pattern conflicts with one already
+// bypassed, or if the pattern is syntactically invalid (for example, an
+// improperly formed wildcard).
+//
 // AddInsecureBypassPattern can be called concurrently with other methods or
 // request handling, and applies to future requests.
 func (c *CrossOriginProtection) AddInsecureBypassPattern(pattern string) {

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -2868,8 +2868,12 @@ func (mux *ServeMux) ServeHTTP(w ResponseWriter, r *Request) {
 // always refers to user code.
 
 // Handle registers the handler for the given pattern.
-// If the given pattern conflicts with one that is already registered, Handle
-// panics.
+//
+// Handle panics if the pattern conflicts with one already registered
+// or if the pattern is syntactically invalid (for example, an
+// improperly formed wildcard).
+//
+// For details on valid patterns and conflict rules, see [ServeMux].
 func (mux *ServeMux) Handle(pattern string, handler Handler) {
 	if use121 {
 		mux.mux121.handle(pattern, handler)
@@ -2879,8 +2883,12 @@ func (mux *ServeMux) Handle(pattern string, handler Handler) {
 }
 
 // HandleFunc registers the handler function for the given pattern.
-// If the given pattern conflicts with one that is already registered, HandleFunc
-// panics.
+//
+// HandleFunc panics if the pattern conflicts with one already
+// registered or if the pattern is syntactically invalid (for example,
+// an improperly formed wildcard).
+//
+// For details on valid patterns and conflict rules, see [ServeMux].
 func (mux *ServeMux) HandleFunc(pattern string, handler func(ResponseWriter, *Request)) {
 	if use121 {
 		mux.mux121.handleFunc(pattern, handler)


### PR DESCRIPTION
Add explicit mention that these methods panic on both pattern conflict and invalid syntax.

- Handle and HandleFunc now note they panic if a pattern conflicts with an existing one or is syntactically invalid (e.g., malformed wildcard).
- AddInsecureBypassPattern now similarly documents panic on conflicts and invalid patterns, bringing consistency and clarity.

See issue #75226 for context and background.

Fixes #75226

---
🔄 **This is a mirror of upstream PR #75297**