### PR TITLE
cmd/link: use zlib.BestSpeed inside machoCompressSection

### DIFF
--- a/src/cmd/link/internal/ld/macho_combine_dwarf.go
+++ b/src/cmd/link/internal/ld/macho_combine_dwarf.go
@@ -6,6 +6,7 @@ package ld
 
 import (
 	imacho "cmd/internal/macho"
+	"log"
 
 	"bytes"
 	"compress/zlib"
@@ -275,7 +276,10 @@ func machoCompressSection(sectBytes []byte) (compressed bool, contents []byte, e
 	binary.BigEndian.PutUint64(sizeBytes[:], uint64(len(sectBytes)))
 	buf.Write(sizeBytes[:])
 
-	z := zlib.NewWriter(&buf)
+	z, err := zlib.NewWriterLevel(&buf, zlib.BestSpeed)
+	if err != nil {
+		log.Fatalf("NewWriterLevel failed: %s", err)
+	}
 	if _, err := z.Write(sectBytes); err != nil {
 		return false, nil, err
 	}


### PR DESCRIPTION
This change modifies Go to use the `zlib.BestSpeed` compression level when compressing DWARF data. The rationale for this mirrors that found in compressSyms: it achieves nearly the same compression level in substantially less time.

---
🔄 **This is a mirror of upstream PR #75512**