### PR TITLE
cmd/compile/internal/ssa: match style and formatting

### DIFF
--- a/src/cmd/compile/internal/ssa/README.md
+++ b/src/cmd/compile/internal/ssa/README.md
@@ -48,8 +48,7 @@ However, certain types don't come from Go and are special; below we will cover
 
 Some operators contain an auxiliary field. The aux fields are usually printed as
 enclosed in `[]` or `{}`, and could be the constant op argument, argument type,
-etc.
-for example:
+etc. For example:
 
 	v13 (?) = Const64 <int> [1]
 


### PR DESCRIPTION
Format final sentence in paragraph and make sentence case to match style.

---
🔄 **This is a mirror of upstream PR #75550**