### PR TITLE
net/http: format pprof.go

### DIFF
--- a/src/net/http/pprof/pprof.go
+++ b/src/net/http/pprof/pprof.go
@@ -352,13 +352,13 @@ func collectProfile(p *pprof.Profile) (*profile.Profile, error) {
 }
 
 var profileSupportsDelta = map[handler]bool{
-	"allocs":       true,
-	"block":        true,
-	"goroutineleak":        true,
-	"goroutine":    true,
-	"heap":         true,
-	"mutex":        true,
-	"threadcreate": true,
+	"allocs":        true,
+	"block":         true,
+	"goroutineleak": true,
+	"goroutine":     true,
+	"heap":          true,
+	"mutex":         true,
+	"threadcreate":  true,
 }
 
 var profileDescriptions = map[string]string{


### PR DESCRIPTION
profileSupportsDelta in pprof.go was not properly formatted wrt whitespaces between keys and values.

---
🔄 **This is a mirror of upstream PR #75769**